### PR TITLE
setup node feature vector for csce datset

### DIFF
--- a/examples/csce/csce_gap.json
+++ b/examples/csce/csce_gap.json
@@ -1,35 +1,57 @@
 {
-    "Verbosity": {
-        "level": 2
-    },
-    "NeuralNetwork": {
-        "Architecture": {
-            "model_type": "PNA",
-            "max_neighbours": 20,
-            "hidden_dim": 55,
-            "num_conv_layers": 6,
-            "output_heads": {
-                "graph":{
-                    "num_sharedlayers": 1,
-                    "dim_sharedlayers": 100,
-                    "num_headlayers": 2,
-                    "dim_headlayers": [50,25]
-                }
-            },
-            "task_weights": [1.0]
-        },
-        "Variables_of_interest": {
-            "input_node_features": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36],
-            "output_index": [0],
-            "type": ["graph"],
-            "denormalize_output": false
-        },
-        "Training": {
-            "num_epoch": 2,
-            "learning_rate": 1e-3,
-            "batch_size": 128,
-            "continue": 0,
-            "startfrom": "existing_model"
+  "Verbosity": {
+    "level": 2
+  },
+  "NeuralNetwork": {
+    "Architecture": {
+      "model_type": "PNA",
+      "max_neighbours": 20,
+      "hidden_dim": 200,
+      "num_conv_layers": 6,
+      "output_heads": {
+        "graph": {
+          "num_sharedlayers": 1,
+          "dim_sharedlayers": 200,
+          "num_headlayers": 2,
+          "dim_headlayers": [
+            200,
+            200
+          ]
         }
+      },
+      "task_weights": [
+        1
+      ]
+    },
+    "Variables_of_interest": {
+      "input_node_features": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "output_index": [
+        0
+      ],
+      "type": [
+        "graph"
+      ],
+      "denormalize_output": false
+    },
+    "Training": {
+      "num_epoch": 10,
+      "learning_rate": 0.001,
+      "batch_size": 128,
+      "continue": 0,
+      "startfrom": "existing_model"
     }
+  }
 }

--- a/examples/csce/ogb_utils.py
+++ b/examples/csce/ogb_utils.py
@@ -85,37 +85,12 @@ def datasets_load(datafile, sampling=None, seed=None):
 
 ##################################################################################################################
 node_attribute_names = [
-    "atomH",
-    "atomB",
     "atomC",
+    "atomF",
+    "atomH",
     "atomN",
     "atomO",
-    "atomF",
-    "atomSi",
-    "atomP",
     "atomS",
-    "atomCl",
-    "atomCa",
-    "atomGe",
-    "atomAs",
-    "atomSe",
-    "atomBr",
-    "atomI",
-    "atomMg",
-    "atomTi",
-    "atomGa",
-    "atomZn",
-    "atomAr",
-    "atomBe",
-    "atomHe",
-    "atomAl",
-    "atomKr",
-    "atomV",
-    "atomNa",
-    "atomLi",
-    "atomCu",
-    "atomNe",
-    "atomNi",
     "atomicnumber",
     "IsAromatic",
     "HSP",
@@ -133,98 +108,31 @@ def gapfromsmiles(smilestr, model):
     return pred[0][0].item()
 
 
-def generate_graphdata_checkelement(simlestr, ytarget, var_config=None):
-    types = {
-        "H": 0,
-        "B": 1,
-        "C": 2,
-        "N": 3,
-        "O": 4,
-        "F": 5,
-        "Si": 6,
-        "P": 7,
-        "S": 8,
-        "Cl": 9,
-        "Ca": 10,
-        "Ge": 11,
-        "As": 12,
-        "Se": 13,
-        "Br": 14,
-        "I": 15,
-        "Mg": 16,
-        "Ti": 17,
-        "Ga": 18,
-        "Zn": 19,
-        "Ar": 20,
-        "Be": 21,
-        "He": 22,
-        "Al": 23,
-        "Kr": 24,
-        "V": 25,
-        "Na": 26,
-        "Li": 27,
-        "Cu": 28,
-        "Ne": 29,
-        "Ni": 30,
-    }
-    bonds = {BT.SINGLE: 0, BT.DOUBLE: 1, BT.TRIPLE: 2, BT.AROMATIC: 3}
+def get_elements_types(smiles_list):
 
     ps = Chem.SmilesParserParams()
     ps.removeHs = False
 
-    mol = Chem.MolFromSmiles(simlestr, ps)  # , sanitize=False , removeHs=False)
-    mol = Chem.AddHs(mol)
-    N = mol.GetNumAtoms()
+    atom_symbols = set()
 
-    type_idx = []
-    atomic_number = []
-    aromatic = []
-    sp = []
-    sp2 = []
-    sp3 = []
-    for atom in mol.GetAtoms():
-        try:
-            type_idx.append(types[atom.GetSymbol()])
-        except:
-            print(atom.GetSymbol())
+    for simlestr in smiles_list:
+        mol = Chem.MolFromSmiles(simlestr, ps)  # , sanitize=False , removeHs=False)
+        mol = Chem.AddHs(mol)
+        for atom in mol.GetAtoms():
+            atom_symbols.add(atom.GetSymbol())
+    atomlist = sorted(atom_symbols)
+    types = {atom: idatom for idatom, atom in enumerate(atomlist)}
+
+    return types
 
 
-def generate_graphdata(simlestr, ytarget, var_config=None):
-    # types = {"H": 0, "C": 1, "N": 2, "O": 3, "F": 4}
-    # B, C, N, O, F, Si, P, S, Cl, Ca, Ge, As, Se, Br, I
-    types = {
-        "H": 0,
-        "B": 1,
-        "C": 2,
-        "N": 3,
-        "O": 4,
-        "F": 5,
-        "Si": 6,
-        "P": 7,
-        "S": 8,
-        "Cl": 9,
-        "Ca": 10,
-        "Ge": 11,
-        "As": 12,
-        "Se": 13,
-        "Br": 14,
-        "I": 15,
-        "Mg": 16,
-        "Ti": 17,
-        "Ga": 18,
-        "Zn": 19,
-        "Ar": 20,
-        "Be": 21,
-        "He": 22,
-        "Al": 23,
-        "Kr": 24,
-        "V": 25,
-        "Na": 26,
-        "Li": 27,
-        "Cu": 28,
-        "Ne": 29,
-        "Ni": 30,
-    }
+def generate_graphdata(
+    simlestr,
+    ytarget,
+    var_config=None,
+    types={"C": 0, "F": 1, "H": 2, "N": 3, "O": 4, "S": 5},
+):
+
     bonds = {BT.SINGLE: 0, BT.DOUBLE: 1, BT.TRIPLE: 2, BT.AROMATIC: 3}
 
     ps = Chem.SmilesParserParams()


### PR DESCRIPTION
The original config file is for [PCQM4Mv2](https://ogb.stanford.edu/docs/lsc/pcqm4mv2) dataset with 31 elements, while in csce dataset, there are only 6 elements. The node feature vector is reduced from 37 (=31+6) to 12 (=6+6), and the adios data file size is also reduced from 111G to 60G.